### PR TITLE
4 create transfer tool for old save manager

### DIFF
--- a/MHWSpeedrunTool/Constants.cs
+++ b/MHWSpeedrunTool/Constants.cs
@@ -16,8 +16,8 @@ namespace MHWSpeedrunTool
 {
     internal class Constants
     {
-        // ENSURE THIS IS FALSE WHEN PUSHING TO MAIN
-        static bool IS_TEST = true;
+        // ENSURE THIS IS FALSE WHEN COMMITTING
+        static bool IS_TEST = false;
 
         // Track management constants
         public static string PINK_RATHIAN_ID = "em001_01";

--- a/MHWSpeedrunTool/Constants.cs
+++ b/MHWSpeedrunTool/Constants.cs
@@ -16,6 +16,10 @@ namespace MHWSpeedrunTool
 {
     internal class Constants
     {
+        // ENSURE THIS IS FALSE WHEN PUSHING TO MAIN
+        static bool IS_TEST = true;
+
+        // Track management constants
         public static string PINK_RATHIAN_ID = "em001_01";
         public static string KIRIN_ID = "em011_00";
         public static string KUSHALA_DAORA_ID = "em024_00";
@@ -46,6 +50,7 @@ namespace MHWSpeedrunTool
         public static string RECESS_ID = "st105";
         public static string HOARFROST_ID = "st108";
 
+        // 
         public static string APP_DATA_PATH = "";
 
         public static AppSettings Settings = new AppSettings();
@@ -57,12 +62,13 @@ namespace MHWSpeedrunTool
         {
             if (string.IsNullOrEmpty(APP_DATA_PATH))
             {
-                APP_DATA_PATH = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\MHWSpeedrunTool";
+                string dataFolderName = IS_TEST ? @"\MHWSpeedrunToolTest" : @"\MHWSpeedrunTool";
+                APP_DATA_PATH = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + dataFolderName;
 
                 if (!Directory.Exists($@"{APP_DATA_PATH}\Track Files"))
                 {
                     Directory.CreateDirectory(APP_DATA_PATH);
-                    TrackService.CopyDirectory(@".\Track Files", $@"{APP_DATA_PATH}\Track Files", true);
+                    FileService.CopyDirectory(@".\Track Files", $@"{APP_DATA_PATH}\Track Files", true);
                 }
             }
 
@@ -74,7 +80,6 @@ namespace MHWSpeedrunTool
             {
                 UiController.SetMhwPath(null, false);
             }
-
         }
     }
 }

--- a/MHWSpeedrunTool/Constants.cs
+++ b/MHWSpeedrunTool/Constants.cs
@@ -62,8 +62,8 @@ namespace MHWSpeedrunTool
         {
             if (string.IsNullOrEmpty(APP_DATA_PATH))
             {
-                string dataFolderName = IS_TEST ? @"\MHWSpeedrunToolTest" : @"\MHWSpeedrunTool";
-                APP_DATA_PATH = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + dataFolderName;
+                APP_DATA_PATH = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+                    + (IS_TEST ? @"\MHWSpeedrunToolTest" : @"\MHWSpeedrunTool");
 
                 if (!Directory.Exists($@"{APP_DATA_PATH}\Track Files"))
                 {

--- a/MHWSpeedrunTool/FileService.cs
+++ b/MHWSpeedrunTool/FileService.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MHWSpeedrunTool
+{
+    public class FileService
+    {
+        public static void CopyDirectory(string sourceDir, string destinationDir, bool recursive, bool overwrite = false)
+        {
+            // Get information about the source directory
+            var dir = new DirectoryInfo(sourceDir);
+
+            // Check if the source directory exists
+            if (!dir.Exists)
+                throw new DirectoryNotFoundException(@$"Source directory not found: {dir.FullName}");
+
+            // Cache directories before we start copying
+            DirectoryInfo[] dirs = dir.GetDirectories();
+
+            // Create the destination directory
+            Directory.CreateDirectory(destinationDir);
+
+            // Get the files in the source directory and copy to the destination directory
+            foreach (FileInfo file in dir.GetFiles())
+            {
+                string targetFilePath = Path.Combine(destinationDir, file.Name);
+                file.CopyTo(targetFilePath, overwrite);
+            }
+
+            // If recursive and copying subdirectories, recursively call this method
+            if (recursive)
+            {
+                foreach (DirectoryInfo subDir in dirs)
+                {
+                    string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                    CopyDirectory(subDir.FullName, newDestinationDir, true);
+                }
+            }
+        }
+    }
+}

--- a/MHWSpeedrunTool/Form1.Designer.cs
+++ b/MHWSpeedrunTool/Form1.Designer.cs
@@ -265,7 +265,7 @@
             lblTeostra.AutoSize = true;
             lblTeostra.Location = new Point(195, 26);
             lblTeostra.Name = "lblTeostra";
-            lblTeostra.Size = new Size(44, 15);
+            lblTeostra.Size = new Size(45, 15);
             lblTeostra.TabIndex = 12;
             lblTeostra.Text = "Teostra";
             // 

--- a/MHWSpeedrunTool/SaveManagement/SaveDataService.cs
+++ b/MHWSpeedrunTool/SaveManagement/SaveDataService.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MHWSpeedrunTool.SaveManagement
+{
+    public class SaveDataService
+    {
+        /**
+         * @param string oldFilePath - Path of the old save manager
+         * Take in the path to the old save manager, and attempt to copy over all backups
+         */
+        public static void TransferSaveListFromOldManager(string oldFilePath)
+        {
+            if(Directory.Exists(oldFilePath + @"\Saves"))
+            {
+                FileService.CopyDirectory(oldFilePath + @"\Saves", $@"{Constants.APP_DATA_PATH}\World\Saves", true, true);
+
+                try
+                {
+                    File.Copy(oldFilePath + @"\MainSave\MainData", $@"{Constants.APP_DATA_PATH}\World\MainSave", true);
+                }
+                catch(FileNotFoundException)
+                {
+                    throw new FailedToLoadMainSaveException();
+                }
+            }
+            else
+            {
+                throw new FailedToLoadExistingSavesException();
+            }
+        }
+
+        public class FailedToLoadMainSaveException : Exception
+        {
+            public FailedToLoadMainSaveException() {}
+        }
+
+        public class FailedToLoadExistingSavesException : Exception
+        {
+            public FailedToLoadExistingSavesException() {}
+        }
+    }
+}

--- a/MHWSpeedrunTool/TrackManagement/TrackService.cs
+++ b/MHWSpeedrunTool/TrackManagement/TrackService.cs
@@ -46,37 +46,5 @@
                 }
             }
         }
-        public static void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
-        {
-            // Get information about the source directory
-            var dir = new DirectoryInfo(sourceDir);
-
-            // Check if the source directory exists
-            if (!dir.Exists)
-                throw new DirectoryNotFoundException(@$"Source directory not found: {dir.FullName}");
-
-            // Cache directories before we start copying
-            DirectoryInfo[] dirs = dir.GetDirectories();
-
-            // Create the destination directory
-            Directory.CreateDirectory(destinationDir);
-
-            // Get the files in the source directory and copy to the destination directory
-            foreach (FileInfo file in dir.GetFiles())
-            {
-                string targetFilePath = Path.Combine(destinationDir, file.Name);
-                file.CopyTo(targetFilePath);
-            }
-
-            // If recursive and copying subdirectories, recursively call this method
-            if (recursive)
-            {
-                foreach (DirectoryInfo subDir in dirs)
-                {
-                    string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
-                    CopyDirectory(subDir.FullName, newDestinationDir, true);
-                }
-            }
-        }
     }
 }

--- a/MHWSpeedrunTool/UiController.cs
+++ b/MHWSpeedrunTool/UiController.cs
@@ -81,6 +81,7 @@ namespace MHWSpeedrunTool
                 }
             }
 
+            // TODO: Attempt to automatically locate the old save manager
             string oldManagerPath = Interaction.InputBox("Enter the path to the old save manager here. \n (can be found by right clicking it in Task Manager and selecting \"Open file location\").");
 
             if(oldManagerPath != "")

--- a/MHWSpeedrunTool/UiController.cs
+++ b/MHWSpeedrunTool/UiController.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Threading.Tasks;
 using static MHWSpeedrunTool.Form1;
 using MHWSpeedrunTool.SteamManagement;
+using System.Net.NetworkInformation;
+using MHWSpeedrunTool.SaveManagement;
 
 namespace MHWSpeedrunTool
 {
@@ -56,6 +58,55 @@ namespace MHWSpeedrunTool
             if(pathLabel != null)
             {
                 pathLabel.Text = GetWorldPathLabelText();
+            }
+        }
+
+        /**
+         * Handles all dialog and calls for transferring save data between the old manager and this tool.
+         * Not currently referenced anywhere, will be triggered from the settings menu once it's created.
+         */
+        public static void TransferDataFromOldSaveManager()
+        {
+            // If any saves exist for world, warn the user that they may overwrite them
+            if(Directory.Exists($@"{Constants.APP_DATA_PATH}\World") && Directory.EnumerateFiles($@"{Constants.APP_DATA_PATH}\World").Any())
+            {
+                DialogResult overwriteResult = MessageBox.Show(
+                    "You have existing save backups for Monster Hunter: World. This operation will overwrite any existing backups that share a name with backups being transferred. Continue?",
+                    "Existing Saves",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning
+                );
+                if (overwriteResult == DialogResult.No)
+                {
+                    return;
+                }
+            }
+
+            string oldManagerPath = Interaction.InputBox("Enter the path to the old save manager here. \n (can be found by right clicking it in Task Manager and selecting \"Open file location\").");
+
+            if(oldManagerPath != "")
+            {
+                string outputMessage = "Successfully transferred saves from the old manager!";
+                string outputHeading = "Success!";
+                MessageBoxIcon outputIcon = MessageBoxIcon.None;
+
+                // The TransferSaveListFromOldManager method handles more detailed exceptions and throws a custom exception so the UI can handle user notification
+                try
+                {
+                    SaveDataService.TransferSaveListFromOldManager(oldManagerPath);
+                }
+                catch (SaveDataService.FailedToLoadExistingSavesException)
+                {
+                    outputMessage = "Unable to locate any existing saves in the old save manager.";
+                    outputIcon = MessageBoxIcon.Error;
+                }
+                catch (SaveDataService.FailedToLoadMainSaveException)
+                {
+                    outputMessage = "Unable to locate a main save backup in the old save manager. All non-main backups were successfully transferred.";
+                    outputIcon = MessageBoxIcon.Error;
+                }
+
+                MessageBox.Show(outputMessage, outputHeading, MessageBoxButtons.OK, outputIcon);
             }
         }
 

--- a/MHWSpeedrunTool/UiController.cs
+++ b/MHWSpeedrunTool/UiController.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading.Tasks;
 using static MHWSpeedrunTool.Form1;
 using MHWSpeedrunTool.SteamManagement;
-using System.Net.NetworkInformation;
 using MHWSpeedrunTool.SaveManagement;
 
 namespace MHWSpeedrunTool


### PR DESCRIPTION
Added a transfer method to both the new class `SaveDataService` and `UiController`. Nothing on the front end is hooked up to the methods yet as the options menu has not been created.

Additionally added the `IS_TEST` property to `Constants` to allow a separate AppData folder to be used for testing, as well as moving the `CopyDirectory` utility method into its own `FileService` class for better organization.