### PR TITLE
Fix transfer from old tool

### DIFF
--- a/MHWSpeedrunTool/AppSettings.cs
+++ b/MHWSpeedrunTool/AppSettings.cs
@@ -71,6 +71,7 @@ namespace MHWSpeedrunTool
         public AppSettings() {
             WorldSaveList = new List<string>();
             WildsSaveList = new List<string>();
+            LoadedTab = Constants.WORLD_TRACKS_TAB;
         }
 
         // Extremely simplistic for now, but will be useful when save management is added

--- a/MHWSpeedrunTool/Constants.cs
+++ b/MHWSpeedrunTool/Constants.cs
@@ -168,6 +168,11 @@ namespace MHWSpeedrunTool
 
             SetFileNames(currentWorldSaves);
             SetFileNames(currentWildsSaves);
+            
+            if(Settings.LoadedTab != null && Settings.LoadedTab.Contains("Saves"))
+            {
+                SaveDataService.SwapState((SaveDataService.LoadedGame)Enum.Parse(typeof(SaveDataService.LoadedGame), Settings.LoadedTab.Replace("Saves", "")));
+            }
 
             SynchronizeSaveList(currentWorldSaves, Settings.WorldSaveList, "World");
             SynchronizeSaveList(currentWildsSaves, Settings.WildsSaveList, "Wilds");

--- a/MHWSpeedrunTool/Form1.cs
+++ b/MHWSpeedrunTool/Form1.cs
@@ -46,7 +46,6 @@ namespace MHWSpeedrunTool
         private void btnLoadWildsSaveForm_Click(object sender, EventArgs e)
         {
             setSaveForm(SaveDataService.LoadedGame.Wilds);
-            Constants.Settings.LoadedTab = Constants.WILDS_SAVE_TAB;
         }
 
         void setSaveForm(SaveDataService.LoadedGame loadedGame)
@@ -106,6 +105,8 @@ namespace MHWSpeedrunTool
         private void btnTransferFromOldManager_Click(object sender, EventArgs e)
         {
             UiController.TransferDataFromOldSaveManager();
+            setSaveForm(SaveDataService.LoadedGame.World);
+            saveForm.RefreshUi();
         }
     }
 }

--- a/MHWSpeedrunTool/SaveManagement/SaveDataService.cs
+++ b/MHWSpeedrunTool/SaveManagement/SaveDataService.cs
@@ -104,6 +104,11 @@ namespace MHWSpeedrunTool.SaveManagement
                 try
                 {
                     File.Copy(oldFilePath + @"\MainSave\MainData", $@"{Constants.APP_DATA_PATH}\World\Main", true);
+
+                    // Load main save, ensuring current state is preserved
+                    Constants.Settings.WorldLoadedSave = "";
+                    SwapState(LoadedGame.World);
+                    LoadSave("Main");
                 }
                 catch(FileNotFoundException)
                 {

--- a/MHWSpeedrunTool/UI/SaveForm.cs
+++ b/MHWSpeedrunTool/UI/SaveForm.cs
@@ -9,7 +9,7 @@ namespace MHWSpeedrunTool
             InitializeComponent();
         }
 
-        void RefreshUi()
+        public void RefreshUi()
         {
             UiController.SetSaveList(lstSaveNames, lblSaveName);
 
@@ -26,6 +26,11 @@ namespace MHWSpeedrunTool
             ToggleButton(cmdLoadSelectedSave, enableBtns, "Load Selected Save", disabledReason);
             ToggleButton(cmdBackupCurrentSave, enableBtns, "Backup Current Save", disabledReason);
             ToggleButton(cmdOverwriteMain, enableBtns, "Overwrite Main", disabledReason);
+
+            if(enableBtns)
+            {
+                cmdLoadMainSave.Enabled = SaveDataService.LoadedSave != "Main";
+            }
         }
 
         void ToggleButton(Button btn, bool btnEnabled, string enabledText, string disabledText)

--- a/MHWSpeedrunTool/UiController.cs
+++ b/MHWSpeedrunTool/UiController.cs
@@ -112,7 +112,7 @@ namespace MHWSpeedrunTool
             if(Directory.Exists($@"{Constants.APP_DATA_PATH}\World") && Directory.EnumerateFiles($@"{Constants.APP_DATA_PATH}\World").Any())
             {
                 DialogResult overwriteResult = MessageBox.Show(
-                    "You have existing save backups for Monster Hunter: World. This operation will overwrite any existing backups that share a name with backups being transferred. Continue?",
+                    "You have existing save backups for Monster Hunter: World. This operation will overwrite any existing backups that share a name with backups being transferred, including your main save. Continue?",
                     "Existing Saves",
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning


### PR DESCRIPTION
Fixed an issue where the UI wouldn't update when transferring World saves from the old save manager.

Load Main Save button is now disabled when the Main save is already loaded.

Added protections on startup to ensure the correct GameState is loaded.