### PR TITLE
36 - Add check for nativePC on every run of loadNativePc

### DIFF
--- a/MHWSpeedrunTool/TrackManagement/TrackService.cs
+++ b/MHWSpeedrunTool/TrackManagement/TrackService.cs
@@ -1,4 +1,7 @@
-﻿namespace MHWSpeedrunTool.TrackManagement
+﻿using MHWSpeedrunTool.SteamManagement;
+using Microsoft.VisualBasic;
+
+namespace MHWSpeedrunTool.TrackManagement
 {
     internal class TrackService
     {
@@ -8,24 +11,43 @@
          */
         public static void BuildNativePc(List<MonsterPattern> trackPatterns)
         {
-            foreach(MonsterPattern pattern in trackPatterns) {
+            string mhwPath = SteamService.FindMhwInstall();
+
+            if (String.IsNullOrEmpty(mhwPath))
+            {
+                while (true)
+                {
+                    mhwPath = Interaction.InputBox("Unable to locate Monster Hunter: World install location. Enter a path for the tracks folder to be output to: ", "No MHW Install");
+
+                    // Cancel if no input
+                    if (String.IsNullOrEmpty(mhwPath)) return;
+
+                    if (Directory.Exists(mhwPath)) break;
+
+                    // If directory does not exist, warn user before looping again
+                    MessageBox.Show("The provided file path does not exist.", "Path Does Not Exist", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+
+            foreach (MonsterPattern pattern in trackPatterns) {
                 foreach(string stageId in pattern.StageToPatternMap.Keys)
                 {
-                    LoadPattern(stageId, pattern.MonsterId, pattern.StageToPatternMap[stageId]);
+                    LoadPattern(stageId, pattern.MonsterId, pattern.StageToPatternMap[stageId], mhwPath);
                 }
             }
         }
 
-        static void LoadPattern(string stageId, string monsterId, int patternNumber)
+        static void LoadPattern(string stageId, string monsterId, int patternNumber, string mhwPath)
         {
-            if (!Directory.Exists(@$"{Constants.Settings.MhwInstallPath}\nativePC\stage\{stageId}"))
+
+            if (!Directory.Exists(@$"{mhwPath}\nativePC\stage\{stageId}"))
             {
-                Directory.CreateDirectory(@$"{Constants.Settings.MhwInstallPath}\nativePC\stage\{stageId}\common\set");
+                Directory.CreateDirectory(@$"{mhwPath}\nativePC\stage\{stageId}\common\set");
             }
 
             for (int i = 1; i <= 3; i++)
             {
-                string fileOutput = @$"{Constants.Settings.MhwInstallPath}\nativePC\stage\{stageId}\common\set\{stageId}_traceSP_{monsterId}_0{i}.sobj";
+                string fileOutput = @$"{mhwPath}\nativePC\stage\{stageId}\common\set\{stageId}_traceSP_{monsterId}_0{i}.sobj";
 
                 if (File.Exists(fileOutput))
                 {


### PR DESCRIPTION
Add a check for nativePC location to the `buildNativePC` method to automatically find the MHW install location. Additionally added a prompt for manual output path entry if the user wants to build a nativePC but doesn't have World installed.