### PR TITLE
Make Wilds save folder deletion recursive

### DIFF
--- a/MHWSpeedrunTool/SaveManagement/WildsState.cs
+++ b/MHWSpeedrunTool/SaveManagement/WildsState.cs
@@ -86,7 +86,7 @@ namespace MHWSpeedrunTool.SaveManagement
 
             try
             {
-                Directory.Delete($@"{Constants.APP_DATA_PATH}\Wilds\{FormatSaveName(saveName)}");
+                Directory.Delete($@"{Constants.APP_DATA_PATH}\Wilds\{FormatSaveName(saveName)}", true);
             }
             catch (Exception e) { }
         }


### PR DESCRIPTION
Set `recursive = true` for the delete method for Wilds Save Management to ensure the folder is properly emptied.